### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.2+15] - May 9, 2023
+
+* Automated dependency updates
+
+
 ## [2.0.2+14] - May 2, 2023
 
 * Automated dependency updates
@@ -266,6 +271,7 @@
 ## [1.0.0+1] - September 6th, 2021
 
 * Initial release
+
 
 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example project for the Automated Testing Framework.'
 publish_to: 'none'
-version: '1.0.0+15'
+version: '1.0.0+16'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -12,7 +12,7 @@ dependencies:
     path: '../'
   flutter: 
     sdk: 'flutter'
-  flutter_map: '^3.1.0'
+  flutter_map: '^4.0.0'
 
 dev_dependencies: 
   flutter_test: 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'automated_testing_framework_plugin_gps'
 description: 'Library to use provide GPS related test steps to the Automated Testing Framework.'
 homepage: 'https://github.com/peiffer-innovations/automated_testing_framework_plugin_gps'
-version: '2.0.2+14'
+version: '2.0.2+15'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -11,11 +11,11 @@ dependencies:
   convert: '^3.1.1'
   flutter: 
     sdk: 'flutter'
-  form_validation: '^2.2.1+6'
+  form_validation: '^3.0.0'
   geolocator: '^9.0.2'
   json_class: '^2.2.1+3'
   logging: '^1.1.1'
-  static_translations: '^2.1.2+11'
+  static_translations: '^2.1.2+12'
 
 dev_dependencies: 
   flutter_test: 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `form_validation`: 2.2.1+6 --> 3.0.0
  * `static_translations`: 2.1.2+11 --> 2.1.2+12


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Running "flutter pub get" in flutter_tools...
Resolving dependencies in ../../../../../opt/hostedtoolcache/flutter/3.7.12-stable/x64/packages/flutter_tools...
  _fe_analyzer_shared 50.0.0 (59.0.0 available)
  analyzer 5.2.0 (5.11.1 available)
  archive 3.3.2 (3.3.7 available)
  args 2.3.1 (2.4.1 available)
  async 2.10.0 (2.11.0 available)
  built_value 8.4.2 (8.5.0 available)
  checked_yaml 2.0.1 (2.0.3 available)
  collection 1.17.0 (1.17.1 available)
  completion 1.0.0 (1.0.1 available)
  coverage 1.6.1 (1.6.3 available)
  crypto 3.0.2 (3.0.3 available)
  dds 2.5.0 (2.8.1 available)
  dds_service_extensions 1.3.1 (1.4.0 available)
  devtools_shared 2.18.0 (2.23.0 available)
  dwds 16.0.2+1 (19.0.0 available)
  fixnum 1.0.1 (1.1.0 available)
  frontend_server_client 3.1.0 (3.2.0 available)
  html 0.15.1 (0.15.3 available)
  http 0.13.5 (0.13.6 available)
  intl 0.17.0 (0.18.1 available)
  io 1.0.3 (1.0.4 available)
  js 0.6.5 (0.6.7 available)
  json_annotation 4.7.0 (4.8.1 available)
  logging 1.1.0 (1.1.1 available)
  matcher 0.12.13 (0.12.16 available)
  meta 1.8.0 (1.9.1 available)
  mime 1.0.2 (1.0.4 available)
  multicast_dns 0.3.2+2 (0.3.2+3 available)
  native_stack_traces 0.5.2 (0.5.5 available)
  node_preamble 2.0.1 (2.0.2 available)
  path 1.8.2 (1.8.3 available)
  petitparser 5.1.0 (5.4.0 available)
  pub_semver 2.1.3 (2.1.4 available)
  pubspec_parse 1.2.1 (1.2.3 available)
  shelf 1.4.0 (1.4.1 available)
  shelf_packages_handler 3.0.1 (3.0.2 available)
  shelf_proxy 1.0.2 (1.0.3 available)
  shelf_static 1.1.1 (1.1.2 available)
  shelf_web_socket 1.0.3 (1.0.4 available)
  source_maps 0.10.11 (0.10.12 available)
  source_span 1.9.1 (1.10.0 available)
  sse 4.1.1 (4.1.2 available)
  test 1.22.0 (1.24.2 available)
  test_api 0.4.16 (0.5.2 available)
  test_core 0.4.20 (0.5.2 available)
  usage 4.1.0 (4.1.1 available)
  vm_service 9.4.0 (11.5.0 available)
  web_socket_channel 2.2.0 (2.4.0 available)
  webdriver 3.0.1 (3.0.2 available)
  xml 6.2.2 (6.3.0 available)
  yaml 3.1.1 (3.1.2 available)
Got dependencies in ../../../../../opt/hostedtoolcache/flutter/3.7.12-stable/x64/packages/flutter_tools!
Running "flutter pub get" in automated_testing_framework_plugin_gps...
Resolving dependencies...


Because automated_testing_framework_plugin_gps depends on automated_testing_framework ^5.0.0+14 which depends on form_validation ^2.2.1+6, form_validation ^2.2.1+6 is required.
So, because automated_testing_framework_plugin_gps depends on form_validation ^3.0.0, version solving failed.
pub get failed
command: "/opt/hostedtoolcache/flutter/3.7.12-stable/x64/bin/cache/dart-sdk/bin/dart __deprecated_pub --directory . get --example"
pub env: {
  "FLUTTER_ROOT": "/opt/hostedtoolcache/flutter/3.7.12-stable/x64",
  "PUB_ENVIRONMENT": "flutter_bot:flutter_cli:get",
  "PUB_CACHE": "/opt/hostedtoolcache/flutter/3.7.12-stable/x64/.pub-cache",
}
exit code: 1


```


dependencies:
  * `flutter_map`: 3.1.0 --> 4.0.0


Error!!!
```
Running "flutter pub get" in example...
Resolving dependencies...


Because every version of automated_testing_framework_plugin_gps from path depends on form_validation ^3.0.0 and automated_testing_framework_example >=2.2.4+10 depends on form_validation ^2.1.0+9, automated_testing_framework_plugin_gps from path is incompatible with automated_testing_framework_example >=2.2.4+10.
So, because example depends on both automated_testing_framework_example ^2.3.2 and automated_testing_framework_plugin_gps from path, version solving failed.
pub get failed
command: "/opt/hostedtoolcache/flutter/3.7.12-stable/x64/bin/cache/dart-sdk/bin/dart __deprecated_pub --directory . get --example"
pub env: {
  "FLUTTER_ROOT": "/opt/hostedtoolcache/flutter/3.7.12-stable/x64",
  "PUB_ENVIRONMENT": "flutter_bot:flutter_cli:get",
  "PUB_CACHE": "/opt/hostedtoolcache/flutter/3.7.12-stable/x64/.pub-cache",
}
exit code: 1


```

